### PR TITLE
Remove extra builds

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,52 +15,8 @@ export default [
     output: [
       {
         file: '0.js',
-        format: 'cjs',
-      },
-      {
-        file: 'builds/terser.js',
-        format: 'cjs',
+        format: 'iife',
         plugins: [
-          terser(),
-        ],
-      },
-      {
-        file: 'builds/closure.js',
-        format: 'cjs',
-        plugins: [
-          closureCompile(),
-        ],
-      },
-      {
-        file: 'builds/closure-terser.js',
-        format: 'cjs',
-        plugins: [
-          closureCompile(),
-          terser(),
-        ],
-      },
-      {
-        file: 'builds/terser-closure.js',
-        format: 'cjs',
-        plugins: [
-          terser(),
-          closureCompile(),
-        ],
-      },
-      {
-        file: 'builds/closure-terser-closure.js',
-        format: 'cjs',
-        plugins: [
-          closureCompile(),
-          terser(),
-          closureCompile(),
-        ],
-      },
-      {
-        file: 'builds/terser-closure-terser.js',
-        format: 'cjs',
-        plugins: [
-          terser(),
           closureCompile(),
           terser(),
         ],


### PR DESCRIPTION
After basic testing, running Closure, then Terser, had the best results. I've removed the extra builds, though we should rerun these tests when we're closing in on the final build.